### PR TITLE
Enable multi-architecture Android builds (ARM/x86)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,42 +10,44 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        runtime: [android-arm, android-arm64, android-x86, android-x64]
     steps:
       - uses: actions/checkout@v4
+      
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x
+      
       - name: Install .NET MAUI
         run: dotnet workload install maui
+      
       - name: Restore dependencies
         run: dotnet restore
+      
       - name: Restore KeyStore
         env:
           KEYSTORE: ${{ secrets.AndroidSigningKeyStore }}
         shell: bash
         run: |
           echo $KEYSTORE | base64 -d > OpenTalkie.keystore
-      - name: Build with KeyStore
+      
+      - name: Build with KeyStore for ${{ matrix.runtime }}
         env:
           KEYSTORE_ALIAS: ${{ secrets.AndroidSigningKeyAlias }}
           KEYSTORE_PASS: ${{ secrets.AndroidSigningKeyPassword }}
         run: |
-          dotnet build OpenTalkie/OpenTalkie.csproj -c Release -f net9.0-android --no-restore -p:AndroidPackageFormats=apk `
+          dotnet publish OpenTalkie/OpenTalkie.csproj -c Release -f net9.0-android -r ${{ matrix.runtime }} --no-restore -p:AndroidPackageFormats=apk `
           -p:AndroidKeyStore=true `
           -p:AndroidSigningKeyAlias=${{ env.KEYSTORE_ALIAS }} `
           -p:AndroidSigningKeyPass=env:KEYSTORE_PASS `
           -p:AndroidSigningKeyStore=${{ github.workspace }}/OpenTalkie.keystore `
           -p:AndroidSigningStorePass=env:KEYSTORE_PASS
-      - name: Upload a Build Artifact
+      
+      - name: Upload APK Artifact for ${{ matrix.runtime }}
         uses: actions/upload-artifact@v4
         with:
-          name: OpenTalkie.apk
-          path: OpenTalkie/bin/Release/net9.0-android/io.github.defectly.opentalkie-Signed.apk
-      - name: Upload Other Stuff
-        uses: actions/upload-artifact@v4
-        with:
-          name: Other Stuff
-          path: |
-            OpenTalkie/bin/Release/net9.0-android/
-            !OpenTalkie/bin/Release/net9.0-android/io.github.defectly.opentalkie-Signed.apk
+          name: OpenTalkie-${{ matrix.runtime }}
+          path: OpenTalkie/bin/Release/net9.0-android/${{ matrix.runtime }}/publish/io.github.defectly.opentalkie-Signed.apk

--- a/OpenTalkie/OpenTalkie.csproj
+++ b/OpenTalkie/OpenTalkie.csproj
@@ -9,6 +9,7 @@
 		The Mac App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;
 		either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
 		<!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
+		<RuntimeIdentifiers>android-arm;android-arm64;android-x86;android-x64</RuntimeIdentifiers>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>OpenTalkie</RootNamespace>
 		<UseMaui>true</UseMaui>


### PR DESCRIPTION
Modified the workflow file to build 4 separate artifacts for each architecture (android-arm, android-arm64, android-x86 and android-x64).
(builds are untested.)